### PR TITLE
feat: remove categorical support

### DIFF
--- a/polars_distance/polars_distance/Cargo.toml
+++ b/polars_distance/polars_distance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars_distance"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 
 [lib]

--- a/polars_distance/polars_distance/src/list.rs
+++ b/polars_distance/polars_distance/src/list.rs
@@ -119,9 +119,8 @@ pub fn jaccard_index(a: &ListChunked, b: &ListChunked) -> PolarsResult<Float64Ch
     } else {
         match a.inner_dtype() {
             DataType::String => elementwise_string_inp(a,b, jacc_str_array),
-            DataType::Categorical(_,_) => elementwise_int_inp(a,b, jacc_int_array::<u32>),
             _ => Err(PolarsError::ComputeError(
-                format!("jaccard index only works on inner dtype Utf8, Categorical and integer. Use of {} is not supported", a.inner_dtype()).into(),
+                format!("jaccard index only works on inner dtype Utf8 and integer. Use of {} is not supported", a.inner_dtype()).into(),
             ))
         }
     }
@@ -138,9 +137,8 @@ pub fn sorensen_index(a: &ListChunked, b: &ListChunked) -> PolarsResult<Float64C
     } else {
         match a.inner_dtype() {
             DataType::String => elementwise_string_inp(a,b, sorensen_str_array),
-            DataType::Categorical(_,_) => elementwise_int_inp(a,b, sorensen_int_array::<u32>),
             _ => Err(PolarsError::ComputeError(
-                format!("sorensen index only works on inner dtype Utf8, Categorical and integer. Use of {} is not supported", a.inner_dtype()).into(),
+                format!("sorensen index only works on inner dtype Utf8 and integer. Use of {} is not supported", a.inner_dtype()).into(),
             ))
         }
     }
@@ -157,9 +155,8 @@ pub fn overlap_coef(a: &ListChunked, b: &ListChunked) -> PolarsResult<Float64Chu
     } else {
         match a.inner_dtype() {
             DataType::String => elementwise_string_inp(a,b, overlap_str_array),
-            DataType::Categorical(_,_) => elementwise_int_inp(a,b, overlap_int_array::<u32>),
             _ => Err(PolarsError::ComputeError(
-                format!("overlap coefficient only works on inner dtype Utf8, Categorical and integer. Use of {} is not supported", a.inner_dtype()).into(),
+                format!("overlap coefficient only works on inner dtype Utf8 and integer. Use of {} is not supported", a.inner_dtype()).into(),
             ))
         }
     }
@@ -176,9 +173,8 @@ pub fn cosine_set_distance(a: &ListChunked, b: &ListChunked) -> PolarsResult<Flo
     } else {
         match a.inner_dtype() {
             DataType::String => elementwise_string_inp(a,b, cosine_str_array),
-            DataType::Categorical(_,_) => elementwise_int_inp(a,b, cosine_int_array::<u32>),
             _ => Err(PolarsError::ComputeError(
-                format!("cosine set distance only works on inner dtype Utf8, Categorical and integer. Use of {} is not supported", a.inner_dtype()).into(),
+                format!("cosine set distance only works on inner dtype Utf8 and integer. Use of {} is not supported", a.inner_dtype()).into(),
             ))
         }
     }
@@ -230,23 +226,8 @@ pub fn tversky_index(
                     _ => None,
                 }))
             },
-            DataType::Categorical(_, _) => {
-                Ok(binary_elementwise(a, b, |a, b| match (a, b) {
-                    (Some(a), Some(b)) => {
-                        let a = a.as_any().downcast_ref::<PrimitiveArray<u32>>().unwrap();
-                        let b = b.as_any().downcast_ref::<PrimitiveArray<u32>>().unwrap();
-                        let s1 = a.into_iter().collect::<PlHashSet<_>>();
-                        let s2 = b.into_iter().collect::<PlHashSet<_>>();
-                        let len_intersect = s1.intersection(&s2).count() as f64;
-                        let len_diff1 = s1.difference(&s2).count();
-                        let len_diff2 = s2.difference(&s1).count();
-                        Some(len_intersect / (len_intersect +  (alpha * len_diff1 as f64) + (beta * len_diff2 as f64)))
-                    }
-                    _ => None,
-                }))
-            },
             _ => Err(PolarsError::ComputeError(
-                format!("tversky index distance only works on inner dtype Utf8, Categorical and integer. Use of {} is not supported", a.inner_dtype()).into(),
+                format!("tversky index distance only works on inner dtype Utf8 and integer. Use of {} is not supported", a.inner_dtype()).into(),
             ))
         }
     }


### PR DESCRIPTION
It's unreliable because even with enabling global string cache it was not picking up the string cache for items that are nested in a list, therefore you could get undesirable results. So removing the support all together until there is a proper solution for it.