### PR TITLE
Add Ratcliff-Obershelp distance metric

### DIFF
--- a/polars_distance/Cargo.toml
+++ b/polars_distance/Cargo.toml
@@ -16,6 +16,7 @@ pyo3-polars = { version = "0.12", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 distances = { version = "1.6.3"}
 rapidfuzz = { version = "0.5.0"}
+gestalt_ratio = { version = "0.2.1"}
 
 [target.'cfg(target_os = "linux")'.dependencies]
 jemallocator = { version = "0.5", features = ["disable_initial_exec_tls"] }

--- a/polars_distance/polars_distance/__init__.py
+++ b/polars_distance/polars_distance/__init__.py
@@ -299,7 +299,7 @@ class DistancePairWiseString:
                 function_name="prefix_str",
                 is_elementwise=True,
             )
-    
+
     def gestalt_ratio(self, other: IntoExpr) -> pl.Expr:
         """Returns gestalt ratio between two expressions"""
         return register_plugin_function(

--- a/polars_distance/polars_distance/__init__.py
+++ b/polars_distance/polars_distance/__init__.py
@@ -305,7 +305,7 @@ class DistancePairWiseString:
         return register_plugin_function(
             plugin_path=Path(__file__).parent,
             args=[self._expr, other],
-            function_name="gestalt_ratio",
+            function_name="gestalt_ratio_str",
             is_elementwise=True,
         )
 

--- a/polars_distance/polars_distance/__init__.py
+++ b/polars_distance/polars_distance/__init__.py
@@ -299,6 +299,15 @@ class DistancePairWiseString:
                 function_name="prefix_str",
                 is_elementwise=True,
             )
+    
+    def gestalt_ratio(self, other: IntoExpr) -> pl.Expr:
+        """Returns gestalt ratio between two expressions"""
+        return register_plugin_function(
+            plugin_path=Path(__file__).parent,
+            args=[self._expr, other],
+            function_name="gestalt_ratio",
+            is_elementwise=True,
+        )
 
 
 @pl.api.register_expr_namespace("dist_list")

--- a/polars_distance/src/expressions.rs
+++ b/polars_distance/src/expressions.rs
@@ -10,7 +10,7 @@ use crate::string::{
     indel_dist, indel_normalized_dist, jaro_dist, jaro_winkler_dist, lcs_seq_dist,
     lcs_seq_normalized_dist, levenshtein_dist, levenshtein_normalized_dist, osa_dist,
     osa_normalized_dist, postfix_dist, postfix_normalized_dist, prefix_dist,
-    prefix_normalized_dist,
+    prefix_normalized_dist, gestalt_ratio
 };
 use distances::vectors::{bray_curtis, canberra, chebyshev, l3_norm, l4_norm, manhattan};
 use polars::prelude::*;
@@ -462,4 +462,17 @@ fn haversine_struct(inputs: &[Series], kwargs: HaversineKwargs) -> PolarsResult<
         }
         _ => unimplemented!(),
     })
+}
+
+
+#[polars_expr(output_type=Float64)]
+fn gestalt_ratio_str(inputs: &[Series]) -> PolarsResult<Series> {
+    if inputs[0].dtype() != &DataType::String || inputs[1].dtype() != &DataType::String {
+        polars_bail!(InvalidOperation: "Gestalt ratio distance works only on Utf8 types. Please cast to Utf8 first.");
+    }
+    let x = inputs[0].str()?;
+    let y = inputs[1].str()?;
+
+    let out: Float64Chunked = arity::binary_elementwise_values(x, y, gestalt_ratio);
+    Ok(out.into_series())
 }

--- a/polars_distance/src/expressions.rs
+++ b/polars_distance/src/expressions.rs
@@ -464,7 +464,6 @@ fn haversine_struct(inputs: &[Series], kwargs: HaversineKwargs) -> PolarsResult<
     })
 }
 
-
 #[polars_expr(output_type=Float64)]
 fn gestalt_ratio_str(inputs: &[Series]) -> PolarsResult<Series> {
     if inputs[0].dtype() != &DataType::String || inputs[1].dtype() != &DataType::String {

--- a/polars_distance/src/string.rs
+++ b/polars_distance/src/string.rs
@@ -1,4 +1,5 @@
 use rapidfuzz::distance::*;
+use gestalt_ratio::gestalt_ratio as _gestalt_ratio;
 
 // HAMMING
 pub fn hamming_dist(x: &str, y: &str) -> u32 {
@@ -88,4 +89,8 @@ pub fn prefix_dist(x: &str, y: &str) -> u32 {
 
 pub fn prefix_normalized_dist(x: &str, y: &str) -> f64 {
     prefix::normalized_distance(x.chars(), y.chars())
+}
+
+pub fn gestalt_ratio(x: &str, y: &str) -> f64 {
+    _gestalt_ratio(x, y)
 }

--- a/polars_distance/tests/test_distance_arr.py
+++ b/polars_distance/tests/test_distance_arr.py
@@ -267,3 +267,17 @@ def test_haversine(unit, value):
     )
 
     assert_frame_equal(result, expected)
+
+
+def test_gestalt(data):
+    result = data.select(
+        pld.col('str_l').dist_str.gestalt_ratio(pld.col('str_r')).alias('dist_gestalt')
+    )
+
+    expected = pl.DataFrame(
+        [
+            pl.Series("dist_gestalt", [0.8], dtype=pl.Float64),
+        ]
+    )
+
+    assert_frame_equal(result, expected)

--- a/polars_distance/tests/test_distance_arr.py
+++ b/polars_distance/tests/test_distance_arr.py
@@ -271,7 +271,7 @@ def test_haversine(unit, value):
 
 def test_gestalt(data):
     result = data.select(
-        pld.col('str_l').dist_str.gestalt_ratio(pld.col('str_r')).alias('dist_gestalt')
+        pld.col("str_l").dist_str.gestalt_ratio(pld.col("str_r")).alias("dist_gestalt")
     )
 
     expected = pl.DataFrame(


### PR DESCRIPTION
This PR adds the gestalt ratio / Ratcliff-Obershelp distance score (https://en.wikipedia.org/wiki/Gestalt_pattern_matching) as an additional string distance metric. Rust crate [`gestalt_ratio`](https://docs.rs/gestalt_ratio/latest/gestalt_ratio/) is added as a dependency, and one new Polars function is created:

```
df.select(pl.col('a').dist_str.gestalt_ratio(pl.col('b')))
```