### PR TITLE
Alias `polars` import to short form `pl` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The docs can be found here: https://ion-elgreco.github.io/polars-distance/
 ## Examples
 
 ```python
-import polars
+import polars as pl
 import polars_distance as pld
 
 df = pl.DataFrame({


### PR DESCRIPTION
Ran into `NameError: name 'pl' is not defined. Did you mean: 'pld'?` when running the example.