### PR TITLE
Use correct package for Polars typing

### DIFF
--- a/polars_distance/polars_distance/__init__.py
+++ b/polars_distance/polars_distance/__init__.py
@@ -2,10 +2,14 @@ from typing import Iterable, Literal, Protocol, cast
 
 import polars as pl
 from pathlib import Path
-from polars._typing import IntoExpr, PolarsDataType   # This should be changed to polars.typing once that package has been released. For now, using the temporary internal package as advised by Polars.
 from polars.plugins import register_plugin_function
 from ._internal import __version__ as __version__
 
+# Import typing - this will eventually move to polars.typing, but currently we use the internal package and fallback to the old package for older versions of Polars.
+try:
+    from polars._typing import IntoExpr, PolarsDataType
+except ImportError:
+    from polars.type_aliases import IntoExpr, PolarsDataType  # type: ignore[no-redef]
 
 @pl.api.register_expr_namespace("dist")
 class DistancePairWise:

--- a/polars_distance/polars_distance/__init__.py
+++ b/polars_distance/polars_distance/__init__.py
@@ -2,7 +2,7 @@ from typing import Iterable, Literal, Protocol, cast
 
 import polars as pl
 from pathlib import Path
-from polars.type_aliases import IntoExpr, PolarsDataType
+from polars._typing import IntoExpr, PolarsDataType   # This should be changed to polars.typing once that package has been released. For now, using the temporary internal package as advised by Polars.
 from polars.plugins import register_plugin_function
 from ._internal import __version__ as __version__
 


### PR DESCRIPTION
Fixes #22 by changing import to `polars._typing`, as `polars.type_aliases` is deprecated.

It's worth noting that this should eventually be changed to `polars.typing` once this has been done (see https://github.com/pola-rs/polars/issues/17420).